### PR TITLE
Support for Windows on Arm64 (WoA) in build-jre.sh

### DIFF
--- a/releng/org.eclipse.justj.releng/build-jre.sh
+++ b/releng/org.eclipse.justj.releng/build-jre.sh
@@ -46,9 +46,22 @@ if [[ $OSTYPE == darwin* ]]; then
   fi
 elif [[ $OSTYPE == cygwin ||  $OSTYPE = msys ]]; then
   os=win
-  jdk_suffix="_windows-x64_bin.zip"
-  eclipse_suffix="-win32-x86_64.zip"
-  jre_suffix="win32-x86_64"
+
+  if [[ "$ARCH" == "" ]]; then
+    arch=x86_64
+  else
+    arch=$ARCH
+  fi
+
+  if [[ "$arch" == aarch64 ]]; then
+    jdk_suffix="_windows-aarch64_bin.zip"
+    eclipse_suffix="-win32-aarch64.zip"
+    jre_suffix="win32-aarch64"
+  else
+    jdk_suffix="_windows-x64_bin.zip"
+    eclipse_suffix="-win32-x86_64.zip"
+    jre_suffix="win32-x86_64"
+  fi
   jdk_relative_bin_folder="bin"
   jdk_relative_lib_folder="lib"
   jdk_relative_vm_arg="bin"
@@ -129,7 +142,11 @@ fi
 
 # Download an os-specific version of Eclipse.
 #
-eclipse_url="https://download.eclipse.org/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24$eclipse_suffix"
+if [[ "$ECLIPSE_URL" == "" ]]; then
+  eclipse_url="https://download.eclipse.org/eclipse/downloads/drops4/R-4.24-202206070700/eclipse-SDK-4.24$eclipse_suffix"
+else
+  eclipse_url=$ECLIPSE_URL
+fi
 eclipse_file=${eclipse_url##*/}
 
 if [ ! -f $eclipse_file ]; then


### PR DESCRIPTION
With this PR, on an WoA box and using a [MSYS2](https://www.msys2.org/wiki/arm64/) terminal, here are the steps to package the JREs for WoA platform using the latest [OpenJDK 17](https://learn.microsoft.com/en-us/java/openjdk/download) built by Microsoft for WoA:
```sh
$ cd releng/org.eclipse.justj.releng
$ export ARCH=aarch64
$ export ECLIPSE_URL=https://github.com/chirontt/eclipse.platform.releng.aggregator/releases/download/R4_26_win32_aarch64/eclipse-SDK-4.26-win32-aarch64.zip
$ export JDK_URLS_WINDOWS=https://aka.ms/download-jdk/microsoft-jdk-17.0.5-windows-aarch64.zip
$ ./build-jre.sh
```
I've made the resulting (unofficial) JRE 17.0.5 packages for WoA [available](https://github.com/chirontt/justj/releases) in my fork.