### PR TITLE
Include executable name in -vm arg on Linux

### DIFF
--- a/releng/org.eclipse.justj.releng/build-jre.sh
+++ b/releng/org.eclipse.justj.releng/build-jre.sh
@@ -89,8 +89,8 @@ else
 
   jdk_relative_bin_folder="bin"
   jdk_relative_lib_folder="lib"
-  jdk_relative_vm_arg="bin"
-  jre_relative_vm_arg="bin"
+  jdk_relative_vm_arg="bin/java"
+  jre_relative_vm_arg="bin/java"
   strip_debug="--strip-debug"
   eclipse_root="eclipse"
   eclipse_executable="eclipse/eclipse"


### PR DESCRIPTION
On Linux the -vm arg is used as the executable to restart Eclipse's child java process, without the "java" part of the name the eclipse process tries to launch the directory ...bin/ and it fails.

Fixes #2